### PR TITLE
Make CrunchyLib picture loading play nicer with NMI handlers doing their own bankswitching

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,27 @@ Then, just define the memory locations and include the crunchylib.asm file gener
     CRUNCHY_SPRITE_PAGE = $xyz
     .include "crunchylib.asm"
 
+### Defining the CRUNCHY_BANK_SWITCH_A macro
+
+To allow CrunchyLib's picture loading routines to be interrupted by an NMI playing music, you will likely need to store the current bankswitching configuration in your own engine's internal variables. For this reason, CrunchyNES requires you to define a macro CRUNCHY_BANK_SWITCH_A.
+
+This macro must be defined before including crunchylib.asm and can be defined in CA65 macro syntax as:
+
+    .MACRO CRUNCHY_BANK_SWITCH_A
+        sta $C000
+        sta MyOwnGameEngineVarBankBits
+    .ENDMACRO
+
+Or equally in ASM6 macro syntax:
+
+    .MACRO CRUNCHY_BANK_SWITCH_A
+        sta $C000
+        sta MyOwnGameEngineVarBankBits
+    .ENDM
+
+
+You can also potentially use the CRUNCHY_BANK_SWITCH_A macro to implement support for some other mapper. But keep in mind that due to its strict timing requirements the NMI display code does *not* use this macro, and would have to be manually re-purposed.
+
 ### Calling the NMI display code
 
 To correctly display pictures, CrunchyLib contains a sub-routine CrunchyLib_Display which has to be called in your NMI *before* the end of vblank.

--- a/asm/crunchylib.asm
+++ b/asm/crunchylib.asm
@@ -733,7 +733,7 @@ CrunchyLib_CopyChrToNextBank:
     pha
     lda @bankBits
     ; Switch to this bank
-    sta $C000
+    CRUNCHY_BANK_SWITCH_A
     jsr @setChrPageAddr
     ldx #0
     lda $2007
@@ -746,7 +746,7 @@ CrunchyLib_CopyChrToNextBank:
     lda @bankBits
     clc
     adc #(1 << 5)
-    sta $C000
+    CRUNCHY_BANK_SWITCH_A
     jsr @setChrPageAddr
     ldx #0
 @writeChrPageLoop:
@@ -777,7 +777,7 @@ CrunchyLib_SwitchCHR:
     clc
     adc CrunchyVar_chrBankBits
     ora #CRUNCHY_PRG_BANK
-    sta $C000
+    CRUNCHY_BANK_SWITCH_A
     rts
 
 CrunchyLib_UploadCompressedNametableBlock:

--- a/asm/crunchyview.asm
+++ b/asm/crunchyview.asm
@@ -381,9 +381,6 @@ ReloadPicture:
     sta $2001
     lda #$90
     sta $2000
-
-    lda #$90
-    sta $2000
     rts
 
 LoadPicture:

--- a/asm/main_asm6.asm
+++ b/asm/main_asm6.asm
@@ -12,6 +12,13 @@ CRUNCHY_TEMP                 = $00
 CRUNCHY_VARS                 = $10
 TOKUMARU_DECOMPRESS_MEM_BASE = $20
 
+;
+; Declare macro for bank-switching. This can be a trivial one as CrunchyView disables NMIs during picture loading.
+;
+.MACRO CRUNCHY_BANK_SWITCH_A
+    sta $C000
+.ENDM
+
 .org $8000
 .include "crunchylib.asm"
 

--- a/asm/main_ca65.asm
+++ b/asm/main_ca65.asm
@@ -14,6 +14,13 @@ CRUNCHY_TEMP                 = $00
 CRUNCHY_VARS                 = $10
 TOKUMARU_DECOMPRESS_MEM_BASE = $20
 
+;
+; Declare macro for bank-switching. This can be a trivial one as CrunchyView disables NMIs during picture loading.
+;
+.MACRO CRUNCHY_BANK_SWITCH_A
+    sta $C000
+.ENDMACRO
+
 .segment "CRUNCHYLIB"
 .include "crunchylib.asm"
 


### PR DESCRIPTION
* Add requirement of a macro CRUNCHY_BANK_SWITCH_A to allow user to define how to save bank-switching state in their engine
* Add trivial non-NMI-safe version of CRUNCHY_BANK_SWITCH_A for CrunchyView
* Update README integration section with instructions on defining CRUNCHY_BANK_SWITCH_A macro